### PR TITLE
Fix not up-to-date keycloak realm for localenv docker compose

### DIFF
--- a/deployment/keycloak/imports/realm.json
+++ b/deployment/keycloak/imports/realm.json
@@ -78,19 +78,19 @@
         "attributes": {}
       },
       {
-        "name": "ROLE_admin",
+        "name": "admin",
         "composite": false,
         "clientRole": false,
         "attributes": {}
       },
       {
-        "name": "ROLE_reader",
+        "name": "reader",
         "composite": false,
         "clientRole": false,
         "attributes": {}
       },
       {
-        "name": "ROLE_user",
+        "name": "user",
         "composite": false,
         "clientRole": false,
         "attributes": {}
@@ -609,7 +609,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "PBcaT08RLn3TtaFcSO9HtDVuKkyhxBuF",
+      "secret": "smartparkingconfig",
       "redirectUris": [
         "*"
       ],
@@ -675,7 +675,7 @@
             "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
-            "claim.name": "roles",
+            "claim.name": "realm_access.roles",
             "jsonType.label": "String"
           }
         }
@@ -2113,7 +2113,7 @@
       "requiredActions": [],
       "realmRoles": [
         "default-roles-smartparkingconfig",
-        "ROLE_admin"
+        "admin"
       ],
       "notBefore": 0
     },
@@ -2135,7 +2135,7 @@
       "requiredActions": [],
       "realmRoles": [
         "default-roles-smartparkingconfig",
-        "ROLE_reader"
+        "reader"
       ],
       "notBefore": 0
     },
@@ -2157,7 +2157,7 @@
       "requiredActions": [],
       "realmRoles": [
         "default-roles-smartparkingconfig",
-        "ROLE_user"
+        "user"
       ],
       "notBefore": 0
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed the realm.json that is automatically imported into localenv keycloak to make it work again with the Spring Security config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The problem was that I changed the Userinfo token processing logic for Spring Security a while ago. It now adds "ROLE_" to the extracted role names (as I don't like to have Spring Security implementation details in the Keycloak config). Also, the role list is expected to be in the claim "realm_access.roles", which is default in Keycloak.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I used the `localenv-docker-compose.yml` (and removed the environment including volumes before) for testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
