### PR TITLE
retrieve image dimensions from uploaded image bytes

### DIFF
--- a/service/src/main/java/de/starwit/service/impl/ImageService.java
+++ b/service/src/main/java/de/starwit/service/impl/ImageService.java
@@ -1,8 +1,14 @@
 package de.starwit.service.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,13 +17,10 @@ import de.starwit.persistence.entity.ImageEntity;
 import de.starwit.persistence.entity.ObservationAreaEntity;
 import de.starwit.persistence.repository.ImageRepository;
 
-/**
- * 
- * Image Service class
- *
- */
 @Service
 public class ImageService implements ServiceInterface<ImageEntity, ImageRepository> {
+
+    static final Logger LOG = LoggerFactory.getLogger(ImageService.class);
 
     @Autowired
     private ImageRepository imageRepository;
@@ -47,7 +50,13 @@ public class ImageService implements ServiceInterface<ImageEntity, ImageReposito
         imageEntity.setName(observationAreaEntity.getName());
         imageEntity.setType(imageFile.getContentType());
         imageEntity.setData(imageFile.getBytes());
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(imageFile.getBytes());
+        BufferedImage bImage = ImageIO.read(bis);
+        observationAreaEntity.setImageHeight(bImage.getHeight());
+        observationAreaEntity.setImageWidth(bImage.getWidth());
         imageEntity.setObservationArea(observationAreaEntity);
+
         return imageRepository.save(imageEntity);
     }
 


### PR DESCRIPTION
Image dimensions are saved to ObservationArea again

## Description
Read image dimensions from uploaded bytes.

## Motivation and Context
Image dimensions are necessary to calculate coordinate transformation.

## How has this been tested?
Uploaded png, jpg files

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
