### PR TITLE
Feature/ab#2271 live traffic on map

### DIFF
--- a/webclient/app/src/app/commons/mapMenu/MapMenuLayout.jsx
+++ b/webclient/app/src/app/commons/mapMenu/MapMenuLayout.jsx
@@ -1,0 +1,25 @@
+import {ToggleButtonGroup} from "@mui/material";
+
+function MapMenuLayout(props) {
+    const {children, value, onChange} = props;
+
+    return (
+        <ToggleButtonGroup size='small'
+            sx={{
+                position: 'fixed',
+                right: 10,
+                top: 60,
+                zIndex: 1,
+                gap: 1
+            }}
+            value={value}
+            orientation="vertical"
+            onChange={onChange}
+            color='success'
+        >
+            {children}
+        </ToggleButtonGroup>
+    );
+}
+
+export default MapMenuLayout;

--- a/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
+++ b/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
@@ -1,0 +1,21 @@
+import TimeToLeaveIcon from '@mui/icons-material/TimeToLeave';
+import {useContext} from 'react';
+import StyledToggleButton from './StyledToggleButton';
+import { useTranslation } from 'react-i18next';
+import { Box } from '@mui/material';
+
+function ObservationMapMenu(props) {
+    const {setToggleLiveTracking} = props;
+    const {t} = useTranslation();
+
+    return (
+        <>
+            <StyledToggleButton title={t('map.live')} value="live" aria-label="live" onClick={setToggleLiveTracking}  >
+                <TimeToLeaveIcon variant="contained" />
+            </StyledToggleButton>
+            <Box sx={{paddingBottom: 5}} />
+        </>
+    );
+}
+
+export default ObservationMapMenu;

--- a/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
+++ b/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
@@ -1,8 +1,8 @@
-import TimeToLeaveIcon from '@mui/icons-material/TimeToLeave';
 import {useContext} from 'react';
 import StyledToggleButton from './StyledToggleButton';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
+import CameraIcon from '@mui/icons-material/Camera';
 
 function ObservationMapMenu(props) {
     const {setToggleLiveTracking, showLive} = props;
@@ -11,7 +11,7 @@ function ObservationMapMenu(props) {
     return (
         <>
             <StyledToggleButton title={t('map.live')} value="live" aria-label="live" onClick={setToggleLiveTracking}  >
-                <TimeToLeaveIcon variant="contained" sx={{ color: showLive ? 'green' : 'inherit' }} />
+                <CameraIcon variant="contained" sx={{ color: showLive ? 'green' : 'inherit' }} />
             </StyledToggleButton>
             <Box sx={{paddingBottom: 5}} />
         </>

--- a/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
+++ b/webclient/app/src/app/commons/mapMenu/ObservationMapMenu.jsx
@@ -5,13 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
 function ObservationMapMenu(props) {
-    const {setToggleLiveTracking} = props;
+    const {setToggleLiveTracking, showLive} = props;
     const {t} = useTranslation();
 
     return (
         <>
             <StyledToggleButton title={t('map.live')} value="live" aria-label="live" onClick={setToggleLiveTracking}  >
-                <TimeToLeaveIcon variant="contained" />
+                <TimeToLeaveIcon variant="contained" sx={{ color: showLive ? 'green' : 'inherit' }} />
             </StyledToggleButton>
             <Box sx={{paddingBottom: 5}} />
         </>

--- a/webclient/app/src/app/commons/mapMenu/StyledToggleButton.jsx
+++ b/webclient/app/src/app/commons/mapMenu/StyledToggleButton.jsx
@@ -1,0 +1,29 @@
+import {styled, ToggleButton, Tooltip} from "@mui/material";
+
+const ToggleButtonStyling = styled(ToggleButton)(({theme}) => ({
+    "&.Mui-selected:hover, :hover": {
+        backgroundColor: theme.palette.background.grey
+    },
+    "&.Mui-selected": {
+        backgroundColor: theme.palette.background.green
+    },
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: theme.shadows[4],
+    border: "none",
+    color: theme.palette.text.primary
+}));
+
+function StyledToggleButton(props) {
+
+    const {children, value, "aria-label": ariaLabel, title, onClick} = props;
+
+    return (
+        <Tooltip title={title}>
+            <ToggleButtonStyling size='small' value={value} aria-label={ariaLabel} onClick={onClick} color='success'>
+                {children}
+            </ToggleButtonStyling>
+        </Tooltip>
+    );
+}
+
+export default StyledToggleButton;

--- a/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
@@ -17,7 +17,7 @@ const ICON_MAPPING = {
 };
 
 function ObservationAreaMap(props) {
-    const {data, onLoad, viewState, onSelect} = props;
+    const {data, onLoad, viewState, onSelect, showLive} = props;
 
     const streamRest = useMemo(() => new StreamRest(), []);
     const wsClient = useRef(new WebSocketClient());
@@ -37,10 +37,18 @@ function ObservationAreaMap(props) {
             setStreams(streamsAndColors);
 
             wsClient.current.setup(handleMessage, streams);
-            wsClient.current.connect();
         });
         return () => wsClient.current.disconnect();
     }, []);
+
+    useEffect(() => {
+        if(showLive) {
+            wsClient.current.connect();
+        } else {
+            wsClient.current.disconnect();
+
+        }
+    },[showLive]);
 
     // Handle incoming messages from WebSocket
     function handleMessage(trackedObjectList, streamId) {
@@ -125,7 +133,7 @@ function ObservationAreaMap(props) {
 
     function getTooltip({object}) {
         return (
-            object && {
+            object?.image && {
                 html: `\
                 <div>
                     <img src='${window.location.pathname}api/image/as-file/${object.image.id}' width="auto" height="200rem" />

--- a/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
@@ -69,11 +69,11 @@ function ObservationAreaMap(props) {
     
     function setupLiveLayers() {
         return Object.entries(streams).map(([stream, color]) =>
-            createIconLayer(markerList[stream], stream, color)
+            createScatterPlotLayer(markerList[stream], stream, color)
         );
     }
     
-    function createIconLayer(markerArray, streamId, color) {
+    function createScatterPlotLayer(markerArray, streamId, color) {
         return new ScatterplotLayer({
             id: 'IconLayer-' + streamId,
             data: markerArray ?? [],
@@ -83,8 +83,6 @@ function ObservationAreaMap(props) {
             getRadius: .7,
             radiusMinPixels: 7,
             radiusUnits: 'meters',
-            iconAtlas: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png',
-            iconMapping: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.json',
             pickable: true,
         });
     }

--- a/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
@@ -6,10 +6,9 @@ import ColorFunctions from "../../services/ColorFunctions";
 import StreamRest from "../../services/StreamRest";
 import WebSocketClient from "../../services/WebSocketClient";
 import cameraicon from "./../../assets/images/camera3.png";
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import StopIcon from '@mui/icons-material/Stop';
-import { Box } from '@mui/material';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import MapMenuLayout from '../../commons/mapMenu/MapMenuLayout';
+import ObservationMapMenu from '../../commons/mapMenu/ObservationMapMenu';
 
 const MAP_VIEW = new MapView({repeat: true});
 const ICON_MAPPING = {
@@ -17,7 +16,7 @@ const ICON_MAPPING = {
 };
 
 function ObservationAreaMap(props) {
-    const {data, onLoad, viewState, onSelect, showLive} = props;
+    const {data, onLoad, viewState, onSelect, showLive, onToggleLive} = props;
 
     const streamRest = useMemo(() => new StreamRest(), []);
     const wsClient = useRef(new WebSocketClient());
@@ -25,7 +24,6 @@ function ObservationAreaMap(props) {
 
     const [streams, setStreams] = useState({});
     const [markerList, setMarkerList] = useState({});
-
     useEffect(() => {
         streamRest.getAvailableStreams().then(response => {
             const streams = response.data;
@@ -145,6 +143,9 @@ function ObservationAreaMap(props) {
 
     return (
         <>
+            <MapMenuLayout>
+                <ObservationMapMenu setToggleLiveTracking={onToggleLive} />
+            </MapMenuLayout>
             <DeckGL
                 layers={layers}
                 views={MAP_VIEW}

--- a/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
@@ -1,8 +1,15 @@
 import {MapView} from '@deck.gl/core';
 import {TileLayer} from "@deck.gl/geo-layers";
-import {BitmapLayer, IconLayer} from "@deck.gl/layers";
+import {BitmapLayer, IconLayer, ScatterplotLayer} from "@deck.gl/layers";
 import DeckGL from "@deck.gl/react";
+import ColorFunctions from "../../services/ColorFunctions";
+import StreamRest from "../../services/StreamRest";
+import WebSocketClient from "../../services/WebSocketClient";
 import cameraicon from "./../../assets/images/camera3.png";
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
+import { Box } from '@mui/material';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const MAP_VIEW = new MapView({repeat: true});
 const ICON_MAPPING = {
@@ -11,6 +18,70 @@ const ICON_MAPPING = {
 
 function ObservationAreaMap(props) {
     const {data, onLoad, viewState, onSelect} = props;
+
+    const streamRest = useMemo(() => new StreamRest(), []);
+    const wsClient = useRef(new WebSocketClient());
+    const colorFunctions = useRef(new ColorFunctions());
+
+    const [streams, setStreams] = useState({});
+    const [markerList, setMarkerList] = useState({});
+
+    useEffect(() => {
+        streamRest.getAvailableStreams().then(response => {
+            const streams = response.data;
+            const colors = colorFunctions.current.generateDistinctColors(Object.keys(response.data).length);
+            let streamsAndColors = {}
+            streams.forEach((stream, index) => {
+                streamsAndColors[stream] = colors[index];
+            });
+            setStreams(streamsAndColors);
+
+            wsClient.current.setup(handleMessage, streams);
+            wsClient.current.connect();
+        });
+        return () => wsClient.current.disconnect();
+    }, []);
+
+    // Handle incoming messages from WebSocket
+    function handleMessage(trackedObjectList, streamId) {
+        let newMarkers = [];
+        trackedObjectList.forEach(trackedObject => {
+            if (trackedObject.hasGeoCoordinates) {
+                let newMarker = {}
+                newMarker.streamId = trackedObject.streamId;
+                newMarker.id = trackedObject.objectId;
+                newMarker.name = trackedObject.objectId + ' c' + trackedObject.classId;
+                newMarker.class = trackedObject.classId;
+                newMarker.timestamp = trackedObject.receiveTimestamp;
+                newMarker.coordinates = [trackedObject.coordinates.longitude, trackedObject.coordinates.latitude];
+                newMarkers.push(newMarker);
+            } else {
+            }
+        });
+        setMarkerList(prevMarkerList => ({ ...prevMarkerList, [streamId]: newMarkers }));
+    }
+    
+    function setupLiveLayers() {
+        return Object.entries(streams).map(([stream, color]) =>
+            createIconLayer(markerList[stream], stream, color)
+        );
+    }
+    
+    function createIconLayer(markerArray, streamId, color) {
+        return new ScatterplotLayer({
+            id: 'IconLayer-' + streamId,
+            data: markerArray ?? [],
+
+            getFillColor: d => color,
+            getPosition: d => d.coordinates,
+            getRadius: .7,
+            radiusMinPixels: 7,
+            radiusUnits: 'meters',
+            iconAtlas: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png',
+            iconMapping: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.json',
+            pickable: true,
+        });
+    }
 
     const layers = [
         new TileLayer({
@@ -48,7 +119,8 @@ function ObservationAreaMap(props) {
             },
             getSize: d => 5,
             getColor: d => [Math.sqrt(d.exits), 140, 0]
-        })
+        }),
+        ...setupLiveLayers()
     ];
 
     function getTooltip({object}) {

--- a/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaMap.jsx
@@ -144,7 +144,7 @@ function ObservationAreaMap(props) {
     return (
         <>
             <MapMenuLayout>
-                <ObservationMapMenu setToggleLiveTracking={onToggleLive} />
+                <ObservationMapMenu setToggleLiveTracking={onToggleLive} showLive={showLive} />
             </MapMenuLayout>
             <DeckGL
                 layers={layers}

--- a/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
@@ -17,7 +17,8 @@ import StopIcon from '@mui/icons-material/Stop';
 
 function ObservationAreaOverview() {
     const [map, setMap] = useState(false);
-    const [toggleLiveTracking, setToggleLiveTracking] = useState(false);
+    const [isLiveTracking, setIsLiveTracking] = useState(false);
+
     const {t} = useTranslation();
     const observationAreaRest = useMemo(() => new ObservationAreaRest(), []);
     const [observationAreas, setObservationAreas] = useState(null);
@@ -102,7 +103,7 @@ function ObservationAreaOverview() {
                     viewState={viewState} 
                     onLoad={reloadObservationAreas} 
                     onSelect={onSelect} 
-                    showLive={toggleLiveTracking} 
+                    showLive={isLiveTracking} 
                     onToggleLive={toggleLive} />
             );
         }
@@ -160,14 +161,14 @@ function ObservationAreaOverview() {
                     editArea={editArea} 
                     copyArea={copyArea} 
                     deleteArea={promptDeleteArea} 
-                    showLive={toggleLiveTracking}>
+                    showLive={isLiveTracking}>
                     </MapSidebar>);
         }
         return null;
     }
 
     function toggleLive() {
-        setToggleLiveTracking(!toggleLiveTracking);
+        setIsLiveTracking(!isLiveTracking);
     }
 
     return (

--- a/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
@@ -97,7 +97,7 @@ function ObservationAreaOverview() {
     function renderMap() {
         if (map) {
             return (
-                <ObservationAreaMap data={observationAreas} viewState={viewState} onLoad={reloadObservationAreas} onSelect={onSelect} showLive={toggleLiveTracking} />
+                <ObservationAreaMap data={observationAreas} viewState={viewState} onLoad={reloadObservationAreas} onSelect={onSelect} showLive={toggleLiveTracking} onToggleLive={toggleLive} />
             );
         }
         return null;
@@ -196,17 +196,6 @@ function ObservationAreaOverview() {
                     selectedArea={selectedArea}
                     update={reloadObservationAreas}
                 />
-                <Box sx={{
-                    position: 'fixed',
-                    bottom: "5%",
-                    right: "6%"
-                }}>
-                    <Fab color="primary">
-                        {!toggleLiveTracking ?
-                            <PlayArrowIcon onClick={toggleLive} /> :
-                            <StopIcon onClick={toggleLive} />}
-                    </Fab>
-                </Box>
                 <AddFabButton onClick={createArea} />
             </Container>
         </>

--- a/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
@@ -97,7 +97,13 @@ function ObservationAreaOverview() {
     function renderMap() {
         if (map) {
             return (
-                <ObservationAreaMap data={observationAreas} viewState={viewState} onLoad={reloadObservationAreas} onSelect={onSelect} showLive={toggleLiveTracking} onToggleLive={toggleLive} />
+                <ObservationAreaMap 
+                    data={observationAreas} 
+                    viewState={viewState} 
+                    onLoad={reloadObservationAreas} 
+                    onSelect={onSelect} 
+                    showLive={toggleLiveTracking} 
+                    onToggleLive={toggleLive} />
             );
         }
         return null;

--- a/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
+++ b/webclient/app/src/app/features/observationArea/ObservationAreaOverview.jsx
@@ -1,4 +1,4 @@
-import {Container, Typography, Stack, Button, Tooltip} from "@mui/material";
+import {Container, Typography, Stack, Button, Tooltip, Box, Fab} from "@mui/material";
 import React, {useEffect, useMemo, useState} from "react";
 import {Grid} from '@mui/material';
 import {useTranslation} from "react-i18next";
@@ -11,10 +11,13 @@ import ObservationAreaCard from "./ObservationAreaCard";
 import ObservationAreaMap from "./ObservationAreaMap";
 import {ViewList, Map, Camera} from "@mui/icons-material";
 import MapSidebar from "./MapSidebar";
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
 
 
 function ObservationAreaOverview() {
     const [map, setMap] = useState(false);
+    const [toggleLiveTracking, setToggleLiveTracking] = useState(false);
     const {t} = useTranslation();
     const observationAreaRest = useMemo(() => new ObservationAreaRest(), []);
     const [observationAreas, setObservationAreas] = useState(null);
@@ -94,7 +97,7 @@ function ObservationAreaOverview() {
     function renderMap() {
         if (map) {
             return (
-                <ObservationAreaMap data={observationAreas} viewState={viewState} onLoad={reloadObservationAreas} onSelect={onSelect} />
+                <ObservationAreaMap data={observationAreas} viewState={viewState} onLoad={reloadObservationAreas} onSelect={onSelect} showLive={toggleLiveTracking} />
             );
         }
         return null;
@@ -144,9 +147,21 @@ function ObservationAreaOverview() {
 
     function renderSidebar() {
         if (map && selectedArea != null) {
-            return (<MapSidebar selected={selectedArea} observationAreas={observationAreas} editArea={editArea} copyArea={copyArea} deleteArea={promptDeleteArea} ></MapSidebar>);
+            return (<MapSidebar 
+                    selected={selectedArea} 
+                    observationAreas={observationAreas} 
+                    onSelect={onSelect} 
+                    editArea={editArea} 
+                    copyArea={copyArea} 
+                    deleteArea={promptDeleteArea} 
+                    showLive={toggleLiveTracking}>
+                    </MapSidebar>);
         }
         return null;
+    }
+
+    function toggleLive() {
+        setToggleLiveTracking(!toggleLiveTracking);
     }
 
     return (
@@ -181,6 +196,17 @@ function ObservationAreaOverview() {
                     selectedArea={selectedArea}
                     update={reloadObservationAreas}
                 />
+                <Box sx={{
+                    position: 'fixed',
+                    bottom: "5%",
+                    right: "6%"
+                }}>
+                    <Fab color="primary">
+                        {!toggleLiveTracking ?
+                            <PlayArrowIcon onClick={toggleLive} /> :
+                            <StopIcon onClick={toggleLive} />}
+                    </Fab>
+                </Box>
                 <AddFabButton onClick={createArea} />
             </Container>
         </>

--- a/webclient/app/src/app/services/ColorFunctions.js
+++ b/webclient/app/src/app/services/ColorFunctions.js
@@ -1,0 +1,28 @@
+import convert from 'color-convert';
+
+class ColorFunctions {
+
+    generateDistinctColors(n) {
+        const colors = [];
+        // Use golden ratio to help spread the hues evenly
+        const goldenRatio = 0.618033988749895;
+        let hue = 0;
+
+        for (let i = 0; i < n; i++) {
+            hue = (hue + goldenRatio) % 1; // Use golden ratio to increment hue
+            
+            const h = Math.round(hue * 360); // Convert to 0-360 range for hue
+            const s = 100; // Saturation at 100%
+            const l = 30;  // Lightness at 50% for vibrant colors
+            
+            // Use color-convert to transform HSL to RGB (0-255 range)
+            const rgb = convert.hsl.rgb([h, s, l]);
+            
+            colors.push(rgb);
+        }
+
+        return colors;
+    }
+}
+
+export default ColorFunctions;

--- a/webclient/app/src/localization/translation-de-DE.js
+++ b/webclient/app/src/localization/translation-de-DE.js
@@ -127,6 +127,6 @@ const translationDeDE = {
     "response.save.failed": "Speichern fehlgeschlagen!",
     "confirm.dialog.title": "Bestätigen des Dialog Titels",
     "confirm.dialog.description": "Bestätigen der Dialog Beschreibung",
-    "map.live": "Livedaten"
+    "map.live": "Livedaten anzeigen"
 };
 export default translationDeDE;

--- a/webclient/app/src/localization/translation-de-DE.js
+++ b/webclient/app/src/localization/translation-de-DE.js
@@ -126,6 +126,7 @@ const translationDeDE = {
     "response.save.success": "Speichern erfolgreich.",
     "response.save.failed": "Speichern fehlgeschlagen!",
     "confirm.dialog.title": "Bestätigen des Dialog Titels",
-    "confirm.dialog.description": "Bestätigen der Dialog Beschreibung"
+    "confirm.dialog.description": "Bestätigen der Dialog Beschreibung",
+    "map.live": "Livedaten"
 };
 export default translationDeDE;

--- a/webclient/app/src/localization/translation-en-EN.js
+++ b/webclient/app/src/localization/translation-en-EN.js
@@ -121,6 +121,7 @@ const translationEnEN = {
     "response.save.success": "Saved successfully.",
     "response.save.failed": "Failed to save!",
     "confirm.dialog.title": "Confirm the Dialog Title",
-    "confirm.dialog.description": "Confirm the Dialog Description"
+    "confirm.dialog.description": "Confirm the Dialog Description",
+    "map.live": "Enable Live Tracking"
 };
 export default translationEnEN;


### PR DESCRIPTION
Users can now enable live traffic tracking on map view.

## Description
Add a new filter button on observation aera map, to enable life traffic tracking.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
